### PR TITLE
Feature: Add ca-certificates apt package to kre-go image

### DIFF
--- a/kre-go/Dockerfile
+++ b/kre-go/Dockerfile
@@ -3,6 +3,12 @@ FROM ubuntu:20.04
 # Create kre user.
 ENV USER=kre
 ENV UID=10001
+
+RUN apt update && apt install -y ca-certificates && \
+    apt-get clean && \
+    apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN adduser \
     --disabled-password \
     --gecos "" \


### PR DESCRIPTION
This adds  the `ca-certificates` package that is necessary for https requests to `kre-go` Docker image.

