### PR TITLE
fix(workflow): semantic release jobs fixed for all components

### DIFF
--- a/.github/workflows/kre-entrypoint_release.yaml
+++ b/.github/workflows/kre-entrypoint_release.yaml
@@ -12,91 +12,62 @@ jobs:
   semantic-release:
     name: Semantic Release
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.semantic.outputs.new_release_version }}
+      published: ${{ steps.semantic.outputs.new_release_published }}
     steps:
 
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v1
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v3
+        id: semantic
         with:
-          node-version: 14
-
-      - name: Install dependencies
-        working-directory: ./kre-entrypoint
-        run: npm install
-
-      - name: Create empty release_version file
-        working-directory: ./kre-entrypoint
-        run: touch release_version.txt
-
-      - name: Release
-        id: semantic_release
+          semantic_version: 19
+          branch: main
+          extends: |
+            semantic-release-monorepo
+          working_directory: ./kre-entrypoint
+          extra_plugins: |
+            @semantic-release/git@10.0.1
+            @semantic-release/changelog@6.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.PATNAME }}
-        working-directory: ./kre-entrypoint
-        run: npx semantic-release --debug
-
-      - name: Upload release_version
-        uses: actions/upload-artifact@v2
-        with:
-          name: release_version
-          path: kre-entrypoint/release_version.txt
 
   docker:
-    # TODO: use output from previous job adding an if condiction instead one per step
-    # https://lannonbr.com/blog/2020-04-16-gh-actions-job-outputs
     name: Docker
     runs-on: ubuntu-latest
     needs: semantic-release
+    if: ${{ needs.semantic-release.outputs.published == 'true'}}
     steps:
-
-      - name: Download release_version
-        uses: actions/download-artifact@v2
-        with:
-          name: release_version
-          path: kre-entrypoint
-
-      - name: Read release_version
-        id: release_version
-        # Set RELEASE_VERSION environment variable
-        run: |
-          echo "RELEASE_VERSION=$(cat kre-entrypoint/release_version.txt)" >> $GITHUB_ENV
-          if [ "$RELEASE_VERSION" = "" ]; then
-            echo "::warning::No new version to release."
-          fi
-
       - name: Checkout code
-        if: env.RELEASE_VERSION != ''
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
       - name: Set up QEMU
-        if: env.RELEASE_VERSION != ''
         uses: docker/setup-qemu-action@v1
 
       - name: Set up Docker Buildx
-        if: env.RELEASE_VERSION != ''
         uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub Registry
-        if: env.RELEASE_VERSION != ''
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Push to Docker Hub
-        if: env.RELEASE_VERSION != ''
         uses: docker/build-push-action@v2
         with:
           context: ./kre-entrypoint
           file: ./kre-entrypoint/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
-            konstellation/kre-entrypoint:${{ env.RELEASE_VERSION }}
+            konstellation/kre-entrypoint:${{ needs.semantic-release.outputs.version }}
             konstellation/kre-entrypoint:latest

--- a/.github/workflows/kre-go_release.yaml
+++ b/.github/workflows/kre-go_release.yaml
@@ -12,91 +12,63 @@ jobs:
   semantic-release:
     name: Semantic Release
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.semantic.outputs.new_release_version }}
+      published: ${{ steps.semantic.outputs.new_release_published }}
     steps:
 
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v1
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v3
+        id: semantic
         with:
-          node-version: 14
-
-      - name: Install dependencies
-        working-directory: ./kre-go
-        run: npm install
-
-      - name: Create empty release_version file
-        working-directory: ./kre-go
-        run: touch release_version.txt
-
-      - name: Release
-        id: semantic_release
+          semantic_version: 19
+          branch: main
+          extends: |
+            semantic-release-monorepo
+          working_directory: ./kre-go
+          extra_plugins: |
+            @semantic-release/git@10.0.1
+            @semantic-release/changelog@6.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.PATNAME }}
-        working-directory: ./kre-go
-        run: npx semantic-release --debug
 
-      - name: Upload release_version
-        uses: actions/upload-artifact@v2
-        with:
-          name: release_version
-          path: kre-go/release_version.txt
 
   docker:
-    # TODO: use output from previous job adding an if condiction instead one per step
-    # https://lannonbr.com/blog/2020-04-16-gh-actions-job-outputs
     name: Docker
     runs-on: ubuntu-latest
     needs: semantic-release
+    if: ${{ needs.semantic-release.outputs.published == 'true'}}
     steps:
-
-      - name: Download release_version
-        uses: actions/download-artifact@v2
-        with:
-          name: release_version
-          path: kre-go
-
-      - name: Read release_version
-        id: release_version
-        # Set RELEASE_VERSION environment variable
-        run: |
-          echo "RELEASE_VERSION=$(cat kre-go/release_version.txt)" >> $GITHUB_ENV
-          if [ "$RELEASE_VERSION" = "" ]; then
-            echo "::warning::No new version to release."
-          fi
-
       - name: Checkout code
-        if: env.RELEASE_VERSION != ''
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
       - name: Set up QEMU
-        if: env.RELEASE_VERSION != ''
         uses: docker/setup-qemu-action@v1
 
       - name: Set up Docker Buildx
-        if: env.RELEASE_VERSION != ''
         uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub Registry
-        if: env.RELEASE_VERSION != ''
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Push to Docker Hub
-        if: env.RELEASE_VERSION != ''
         uses: docker/build-push-action@v2
         with:
           context: ./kre-go
           file: ./kre-go/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
-            konstellation/kre-go:${{ env.RELEASE_VERSION }}
+            konstellation/kre-go:${{ needs.semantic-release.outputs.version }}
             konstellation/kre-go:latest

--- a/.github/workflows/krt-files-downloader_release.yaml
+++ b/.github/workflows/krt-files-downloader_release.yaml
@@ -18,85 +18,53 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v1
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v3
+        id: semantic
         with:
-          node-version: 14
-
-      - name: Install dependencies
-        working-directory: ./krt-files-downloader
-        run: npm install
-
-      - name: Create empty release_version file
-        working-directory: ./krt-files-downloader
-        run: touch release_version.txt
-
-      - name: Release
-        id: semantic_release
+          semantic_version: 19
+          branch: main
+          extends: |
+            semantic-release-monorepo
+          working_directory: ./krt-files-downloader
+          extra_plugins: |
+            @semantic-release/git@10.0.1
+            @semantic-release/changelog@6.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.PATNAME }}
-        working-directory: ./krt-files-downloader
-        run: npx semantic-release --debug
-
-      - name: Upload release_version
-        uses: actions/upload-artifact@v2
-        with:
-          name: release_version
-          path: krt-files-downloader/release_version.txt
 
   docker:
-    # TODO: use output from previous job adding an if condition instead one per step
-    # https://lannonbr.com/blog/2020-04-16-gh-actions-job-outputs
     name: Docker
     runs-on: ubuntu-latest
     needs: semantic-release
+    if: ${{ needs.semantic-release.outputs.published == 'true'}}
     steps:
-
-      - name: Download release_version
-        uses: actions/download-artifact@v2
-        with:
-          name: release_version
-          path: krt-files-downloader
-
-      - name: Read release_version
-        id: release_version
-        # Set RELEASE_VERSION environment variable
-        run: |
-          echo "RELEASE_VERSION=$(cat krt-files-downloader/release_version.txt)" >> $GITHUB_ENV
-          if [ "$RELEASE_VERSION" = "" ]; then
-            echo "::warning::No new version to release."
-          fi
-
       - name: Checkout code
-        if: env.RELEASE_VERSION != ''
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
       - name: Set up QEMU
-        if: env.RELEASE_VERSION != ''
         uses: docker/setup-qemu-action@v1
 
       - name: Set up Docker Buildx
-        if: env.RELEASE_VERSION != ''
         uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub Registry
-        if: env.RELEASE_VERSION != ''
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Push to Docker Hub
-        if: env.RELEASE_VERSION != ''
         uses: docker/build-push-action@v2
         with:
           context: ./krt-files-downloader
           file: ./krt-files-downloader/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
-            konstellation/krt-files-downloader:${{ env.RELEASE_VERSION }}
+            konstellation/krt-files-downloader:${{ needs.semantic-release.outputs.version }}
             konstellation/krt-files-downloader:latest

--- a/kre-entrypoint/package.json
+++ b/kre-entrypoint/package.json
@@ -1,26 +1,34 @@
 {
   "name": "kre-entrypoint",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/konstellation-io/kre-runners.git"
-  },
-  "dependencies": {
-    "@semantic-release/exec": "5.0.0",
-    "semantic-release": "17.2.2",
-    "semantic-release-monorepo": "7.0.3"
-  },
+  "version": "0.0.1",
   "release": {
-    "branches": [
-      "main"
-    ],
     "extends": "semantic-release-monorepo",
+    "branches": "main",
     "plugins": [
-      "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
       [
-        "@semantic-release/exec",
+        "@semantic-release/commit-analyzer",
         {
-          "verifyReleaseCmd": "echo ${nextRelease.version} > release_version.txt"
+          "preset": "angular"
+        }
+      ],
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "angular"
+        }
+      ],
+      [
+        "@semantic-release/changelog",
+        {
+          "changelogFile": "CHANGELOG.md"
+        }
+      ],
+      [
+        "@semantic-release/git",
+        {
+          "assets": [
+            "CHANGELOG.md"
+          ]
         }
       ]
     ]

--- a/kre-go/package.json
+++ b/kre-go/package.json
@@ -1,26 +1,34 @@
 {
   "name": "kre-go",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/konstellation-io/kre-runners.git"
-  },
-  "dependencies": {
-    "@semantic-release/exec": "5.0.0",
-    "semantic-release": "17.2.2",
-    "semantic-release-monorepo": "7.0.3"
-  },
+  "version": "0.0.1",
   "release": {
-    "branches": [
-      "main"
-    ],
     "extends": "semantic-release-monorepo",
+    "branches": "main",
     "plugins": [
-      "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
       [
-        "@semantic-release/exec",
+        "@semantic-release/commit-analyzer",
         {
-          "verifyReleaseCmd": "echo ${nextRelease.version} > release_version.txt"
+          "preset": "angular"
+        }
+      ],
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "angular"
+        }
+      ],
+      [
+        "@semantic-release/changelog",
+        {
+          "changelogFile": "CHANGELOG.md"
+        }
+      ],
+      [
+        "@semantic-release/git",
+        {
+          "assets": [
+            "CHANGELOG.md"
+          ]
         }
       ]
     ]

--- a/krt-files-downloader/package.json
+++ b/krt-files-downloader/package.json
@@ -1,26 +1,34 @@
 {
   "name": "krt-files-downloader",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/konstellation-io/kre-runners.git"
-  },
-  "dependencies": {
-    "@semantic-release/exec": "5.0.0",
-    "semantic-release": "17.2.2",
-    "semantic-release-monorepo": "7.0.3"
-  },
+  "version": "0.0.1",
   "release": {
-    "branches": [
-      "main"
-    ],
     "extends": "semantic-release-monorepo",
+    "branches": "main",
     "plugins": [
-      "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
       [
-        "@semantic-release/exec",
+        "@semantic-release/commit-analyzer",
         {
-          "verifyReleaseCmd": "echo ${nextRelease.version} > release_version.txt"
+          "preset": "angular"
+        }
+      ],
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "angular"
+        }
+      ],
+      [
+        "@semantic-release/changelog",
+        {
+          "changelogFile": "CHANGELOG.md"
+        }
+      ],
+      [
+        "@semantic-release/git",
+        {
+          "assets": [
+            "CHANGELOG.md"
+          ]
         }
       ]
     ]


### PR DESCRIPTION
### WHY

Actions for `kre-go`, `kre-entrypoint` and `krt-files-downloader` are not working. The semantic release step does not generate the file with the version that is used by the docker release step, causing the docker release to fail without publishing new versions of the component.

### WHAT

Refactor the affected actions by using the `cycjimmy/semantic-release-action@v3` instead of using custom actions. Also avoid creating a file to move the version to the docker release job and use instead an `output` object.