### PR TITLE
fix(krt-files-downloader): enable release on action

### DIFF
--- a/.github/workflows/krt-files-downloader_release.yaml
+++ b/.github/workflows/krt-files-downloader_release.yaml
@@ -12,6 +12,9 @@ jobs:
   semantic-release:
     name: Semantic Release
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.semantic.outputs.new_release_version }}
+      published: ${{ steps.semantic.outputs.new_release_published }}
     steps:
 
       - name: Checkout code

--- a/krt-files-downloader/internal/domain/usecase/krt_test.go
+++ b/krt-files-downloader/internal/domain/usecase/krt_test.go
@@ -39,7 +39,6 @@ func TestKRTInteractor_DownloadKRTFiles(t *testing.T) {
 	const (
 		runtimeID   = "runtime1234"
 		versionID   = "version1234"
-		runtimeID   = "runtime1234"
 		destination = "_test/output"
 		krtFile     = "_test/greeter-v1.krt"
 	)


### PR DESCRIPTION
### WHY

The release Steps needs the output of the Semantic Release step to be setted.

### What

Sets the output on the semantic release action.