### PR TITLE
fix(kre-go): Deprecate protobuf packages

### DIFF
--- a/kre-go/main.go
+++ b/kre-go/main.go
@@ -36,6 +36,7 @@ func Start(handlerInit HandlerInit, handler Handler) {
 	}
 	defer nc.Close()
 
+	// Connect to JetStream
 	js, err := nc.JetStream()
 	if err != nil {
 		logger.Errorf("Error connecting to JetStream: %s", err)


### PR DESCRIPTION
## Why

[https://pkg.go.dev/github.com/golang/protobuf](https://pkg.go.dev/github.com/golang/protobuf) package is no longer maintained. So we decided to deprecate it in favor to:
[https://pkg.go.dev/google.golang.org/protobuf](https://pkg.go.dev/google.golang.org/protobuf)

## What
- Update packages
- Update go mod files

## Note
Dummy commit to force semantic release bot