### PR TITLE
fix(entrypoint): modify log connection info to credentials leaks

### DIFF
--- a/kre-py/src/kre_runner.py
+++ b/kre-py/src/kre_runner.py
@@ -56,7 +56,7 @@ class Runner:
         Connect to NATS.
         """
 
-        self.logger.info(f"Connecting to MongoDB {self.config.mongo_uri}...")
+        self.logger.info(f"Connecting to MongoDB...")
         self.mongo_conn = pymongo.MongoClient(
             self.config.mongo_uri, socketTimeoutMS=10000, connectTimeoutMS=10000
         )


### PR DESCRIPTION
### WHY

A log with the MongoDB credentials is shown in the KRE UI.

### WHAT

Avoid the MongoDB's connection string in this log.