### PR TITLE
fix(kre-go): bad written if in ack error check

### DIFF
--- a/kre-go/runner.go
+++ b/kre-go/runner.go
@@ -73,7 +73,7 @@ func (r *Runner) ProcessMessage(msg *nats.Msg) {
 	// Tell NATS we don't need to receive the message anymore and we are done processing it.
 	ackErr := msg.Ack()
 	if ackErr != nil {
-		r.logger.Errorf("Error in message ack: %s", err)
+		r.logger.Errorf("Error in message ack: %s", ackErr.Error())
 	}
 	if err != nil {
 		r.stopWorkflowReturningErr(err, r.cfg.NATS.EntrypointSubject)

--- a/kre-go/runner.go
+++ b/kre-go/runner.go
@@ -72,7 +72,7 @@ func (r *Runner) ProcessMessage(msg *nats.Msg) {
 	handlerResult, err := r.handler(hCtx, requestMsg.Payload)
 	// Tell NATS we don't need to receive the message anymore and we are done processing it.
 	ackErr := msg.Ack()
-	if ackErr == nil {
+	if ackErr != nil {
 		r.logger.Errorf("Error in message ack: %s", err)
 	}
 	if err != nil {


### PR DESCRIPTION
## Why
There is a bad written if in the ack error check. It should check if error _different_ from nil.

## What
- Change if condition