### PR TITLE
fix(kre-py): add wait time for ack messages

### DIFF
--- a/kre-entrypoint/src/kre_entrypoint.py
+++ b/kre-entrypoint/src/kre_entrypoint.py
@@ -113,6 +113,7 @@ class EntrypointKRE:
                 subject=input_subject,
                 config=ConsumerConfig(
                     deliver_policy=DeliverPolicy.NEW,
+                    ack_wait = 22 * 3600,  # 22 hours
                 ),
                 manual_ack=True,
             )

--- a/kre-py/src/main.py
+++ b/kre-py/src/main.py
@@ -91,6 +91,7 @@ class NodeRunner(Runner):
                 cb=self.create_message_cb(),
                 config=ConsumerConfig(
                     deliver_policy=DeliverPolicy.NEW,
+                    ack_wait = 22 * 3600,  # 22 hours
                 ),
                 manual_ack=True,
             )


### PR DESCRIPTION
## Why
Ack messages have an awaiting time in which they must be answered before sending again the same message.

## What
- Manually set this time so at least 22h go on before sending again the same message if not answered.