### PR TITLE
fix(kre-go): add wait time for ack messages

### DIFF
--- a/kre-go/main.go
+++ b/kre-go/main.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/nats-io/nats.go"
 	"google.golang.org/protobuf/proto"
@@ -55,7 +56,7 @@ func Start(handlerInit HandlerInit, handler Handler) {
 	runner := NewRunner(logger, cfg, nc, js, handler, handlerInit, mongoM)
 	logger.Infof("Listening to '%s' subject...", cfg.NATS.InputSubject)
 
-	s, err := js.QueueSubscribe(cfg.NATS.InputSubject, cfg.NATS.Stream, runner.ProcessMessage, nats.DeliverNew(), nats.Durable(cfg.NodeName), nats.ManualAck())
+	s, err := js.QueueSubscribe(cfg.NATS.InputSubject, cfg.NATS.Stream, runner.ProcessMessage, nats.DeliverNew(), nats.Durable(cfg.NodeName), nats.ManualAck(), nats.AckWait(22*time.Hour))
 	if err != nil {
 		logger.Errorf("Error subscribing to the NATS subject: %s", err)
 		os.Exit(1)


### PR DESCRIPTION
## Why
Ack messages have an awaiting time in which they must be answered before sending again the same message.

## What
- Manually set this time so at least 22h go on before sending again the same message if not answered.