### PR TITLE
ci: add package.json for semantic release

### DIFF
--- a/kre-exitpoint/package.json
+++ b/kre-exitpoint/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "kre-exitpoint",
+  "version": "0.0.1",
+  "release": {
+    "extends": "semantic-release-monorepo",
+    "branches": "main",
+    "plugins": [
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "angular"
+        }
+      ],
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "angular"
+        }
+      ],
+      [
+        "@semantic-release/changelog",
+        {
+          "changelogFile": "CHANGELOG.md"
+        }
+      ],
+      [
+        "@semantic-release/git",
+        {
+          "assets": [
+            "CHANGELOG.md"
+          ]
+        }
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
# WHY

We need a `package.json` for semantic release to work

# WHAT

Adds a `package.json`