### PR TITLE
fix(kre-exitpoint): fix default handler

### DIFF
--- a/kre-exitpoint/main.go
+++ b/kre-exitpoint/main.go
@@ -17,7 +17,7 @@ func defaultHandler(ctx *kre.HandlerContext, data *anypb.Any) error {
 	ctx.Logger.Info("[exitpoint default handler invoked]")
 
 	if ctx.IsMessageEarlyReply() || ctx.IsMessageEarlyExit() {
-		ctx.SendOutput(data)
+		ctx.SendAny(data)
 	}
 
 	return nil


### PR DESCRIPTION
## Why
Send early reply methods were not working as expected when testing retrocompatibility with krt v1.

## What
- `DefaultHandler` method must use `SendAny`.