### PR TITLE
Revert "chore(deps): bump torch from 1.5.1 to 1.13.1 in /kre-py"

### DIFF
--- a/kre-py/requirements.txt
+++ b/kre-py/requirements.txt
@@ -25,7 +25,7 @@ scipy==1.5.4
 six==1.15.0
 smart-open==3.0.0
 threadpoolctl==2.1.0
-torch==1.5.1
+torch==1.9.0
 torchvision==0.6.1
 tqdm==4.51.0
 urllib3==1.25.11

--- a/kre-py/requirements.txt
+++ b/kre-py/requirements.txt
@@ -25,7 +25,7 @@ scipy==1.5.4
 six==1.15.0
 smart-open==3.0.0
 threadpoolctl==2.1.0
-torch==1.13.1
+torch==1.5.1
 torchvision==0.6.1
 tqdm==4.51.0
 urllib3==1.25.11


### PR DESCRIPTION
Reverts konstellation-io/kre-runners#168 as with the update they remove support for CUDA 10