### PR TITLE
fix(kre-py): fix lifecycle bug for async init functions

### DIFF
--- a/kre-py/src/main.py
+++ b/kre-py/src/main.py
@@ -86,6 +86,8 @@ class NodeRunner(Runner):
             self.handler_init_fn(self.handler_ctx)
 
     async def process_messages(self) -> None:
+        await self.execute_handler_init()
+
         for subject in self.config.nats_inputs:
             queue = f'{subject.replace(".", "-")}-{self.config.krt_node_name}'
             try:
@@ -108,8 +110,6 @@ class NodeRunner(Runner):
                 tb = traceback.format_exc()
                 self.logger.error(f"Error subscribing to NATS subject {subject}: {err}\n\n{tb}")
                 sys.exit(1)
-
-        await self.execute_handler_init()
 
     def create_message_cb(self) -> callable:
         async def message_cb(msg) -> None:
@@ -164,18 +164,18 @@ class NodeRunner(Runner):
         return request_msg
 
     async def __publish_msg__(
-        self,
-        response_payload: Message,
-        request_msg: KreNatsMessage,
-        msg_type: MessageType,
-        channel: str,
+            self,
+            response_payload: Message,
+            request_msg: KreNatsMessage,
+            msg_type: MessageType,
+            channel: str,
     ):
         response_msg = self.new_response_msg(request_msg, msg_type)
         response_msg.payload.Pack(response_payload)
         await self.publish_response(response_msg, channel)
 
     async def __publish_any__(
-        self, response_payload, request_msg: KreNatsMessage, msg_type: MessageType, channel: str
+            self, response_payload, request_msg: KreNatsMessage, msg_type: MessageType, channel: str
     ):
         response_msg = self.new_response_msg(request_msg, msg_type)
         response_msg.payload.CopyFrom(response_payload)
@@ -191,7 +191,7 @@ class NodeRunner(Runner):
         await self.publish_response(msg, channel)
 
     def new_response_msg(
-        self, request_msg: KreNatsMessage, msg_type: MessageType
+            self, request_msg: KreNatsMessage, msg_type: MessageType
     ) -> KreNatsMessage:
         """
         Creates a KreNatsMessage that keeps previous request ID plus adding the payload we wish to send.
@@ -251,7 +251,7 @@ class NodeRunner(Runner):
         return f"{output_subject}.{channel}"
 
     def save_elapsed_time(
-        self, start: datetime, end: datetime, from_node: str, success: bool
+            self, start: datetime, end: datetime, from_node: str, success: bool
     ) -> None:
         """
         Stores in InfluxDB how much time did it take the node to run the handler


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When an error is thrown in an async init function, the subscriptions to the subject of the node will continue receiving data until the process dies.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have created tests for my code changes, and the tests are passing.
- [x] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
