### PR TITLE
Speed up kre-entrypoint Docker image builds by installing pre-compiled wheels for some heavy dependencies

### DIFF
--- a/kre-entrypoint/Dockerfile
+++ b/kre-entrypoint/Dockerfile
@@ -46,7 +46,8 @@ ENV PYTHONUNBUFFERED=1
 RUN apt update && \
     apt -y install python3.7 python3-pip python3.7-dev && \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1 && \
-    update-alternatives --set python3 /usr/bin/python3.7
+    update-alternatives --set python3 /usr/bin/python3.7 && \
+    python3 -m pip install --upgrade pip
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description
Speed up `kre-entrypoint` Docker image builds by installing pre-compiled wheels for some heavy dependencies.

## Motivation and Context
Some dependencies installed at image build time take too long to compile as wheels, specially `grpcio` as it relies on C code. While building wheels is perfectly fine, downloading them already compiled is a much less time-consuming process.

Since the base image this Dockerfile uses is considered a `manylinux` one (see https://github.com/pypa/manylinux), the time installing some dependencies takes can be considerably shortened.

Enabling pre-compiled wheels installation for `manylinux` systems requires upgrading `pip` to a certain version (I'm unsure about which one, though). Hence this PR.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have created tests for my code changes, and the tests are passing.
- [ ] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
